### PR TITLE
Fixing build on Ubuntu (and variants)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OBJS=$(addprefix ${OBJDIR}/,$(subst .cpp,.o,${CXXFILES}))
 all: ${CURDIR}/bin/samrewritten
 
 ${CURDIR}/bin/samrewritten: $(OBJS)
-	${CXX} ${CXXFLAGS} ${LDFLAGS} -o ${CURDIR}/bin/samrewritten $(OBJS)
+	${CXX} ${LDFLAGS} -o ${CURDIR}/bin/samrewritten $(OBJS) ${CXXFLAGS}
 
 ${OBJDIR}/%.o: %.cpp $(HFILES)
 	@mkdir -p $$(dirname $@)


### PR DESCRIPTION
When I tried to build on Xubuntu 18.04 I got multiple linking error whose caused by wrong linking order for the g++

For example:
"gcc test.c -lcurl" will build without error while "gcc -lcurl test.c" will fail because gcc/g++ not find the linkings.