### PR TITLE
Fix for popovermenu and replace trophy emoji

### DIFF
--- a/glade/main_window.glade
+++ b/glade/main_window.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.2 
+<!-- Generated with glade 3.36.0 
 
 Copyright (C) 
 
@@ -41,9 +41,6 @@ telans (telans)</property>
     <property name="artists">Rejedai (rejedai)</property>
     <property name="logo">../assets/icon_256.png</property>
     <property name="license_type">gpl-3-0</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox">
         <property name="can_focus">False</property>
@@ -61,6 +58,9 @@ telans (telans)</property>
           </packing>
         </child>
       </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
     </child>
   </object>
   <object class="GtkBox" id="fetch_achievements_placeholder">
@@ -232,7 +232,7 @@ Give it some time, eventually it'll finish downloading all the pretty icons!</pr
     </child>
   </object>
   <object class="GtkAdjustment" id="modifications_time_amount_adjustment">
-    <property name="upper">1e+42</property>
+    <property name="upper">10000000000000000719354278919532445696</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
@@ -244,9 +244,6 @@ Give it some time, eventually it'll finish downloading all the pretty icons!</pr
     <property name="default_height">200</property>
     <property name="icon">../assets/icon_256.png</property>
     <property name="type_hint">dialog</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child internal-child="vbox">
       <object class="GtkBox">
         <property name="can_focus">False</property>
@@ -500,6 +497,9 @@ Give it some time, eventually it'll finish downloading all the pretty icons!</pr
         </child>
       </object>
     </child>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
   </object>
   <object class="GtkBox" id="no_achievements_found_placeholder">
     <property name="visible">True</property>
@@ -672,6 +672,10 @@ Did you make a typo? Or maybe this game has no stats.</property>
       <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="margin_start">10</property>
+        <property name="margin_end">10</property>
+        <property name="margin_top">10</property>
+        <property name="margin_bottom">10</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkModelButton" id="about_button">
@@ -712,6 +716,17 @@ Did you make a typo? Or maybe this game has no stats.</property>
           </packing>
         </child>
         <child>
+          <object class="GtkSeparator" id="separator_lock">
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="padding">6</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkModelButton" id="unlock_all_achievements_button">
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
@@ -720,7 +735,7 @@ Did you make a typo? Or maybe this game has no stats.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
         <child>
@@ -732,7 +747,7 @@ Did you make a typo? Or maybe this game has no stats.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">5</property>
           </packing>
         </child>
         <child>
@@ -744,7 +759,18 @@ Did you make a typo? Or maybe this game has no stats.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator" id="separator_display">
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="padding">6</property>
+            <property name="position">7</property>
           </packing>
         </child>
         <child>
@@ -757,7 +783,7 @@ Did you make a typo? Or maybe this game has no stats.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">6</property>
+            <property name="position">8</property>
           </packing>
         </child>
         <child>
@@ -770,7 +796,18 @@ Did you make a typo? Or maybe this game has no stats.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">7</property>
+            <property name="position">9</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator" id="separator_timed">
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="padding">6</property>
+            <property name="position">10</property>
           </packing>
         </child>
         <child>
@@ -782,7 +819,7 @@ Did you make a typo? Or maybe this game has no stats.</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">8</property>
+            <property name="position">11</property>
           </packing>
         </child>
       </object>
@@ -797,113 +834,6 @@ Did you make a typo? Or maybe this game has no stats.</property>
     <property name="height_request">500</property>
     <property name="can_focus">False</property>
     <property name="icon">../assets/icon_256.png</property>
-    <child type="titlebar">
-      <object class="GtkHeaderBar">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="title">SamRewritten</property>
-        <property name="subtitle">Steam Achievement Manager</property>
-        <property name="show_close_button">True</property>
-        <child>
-          <object class="GtkButton" id="back_button">
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Return to the game list</property>
-            <child>
-              <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">go-previous-symbolic</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSearchEntry" id="game_search_bar">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="width_chars">26</property>
-            <property name="primary_icon_name">edit-find-symbolic</property>
-            <property name="primary_icon_activatable">False</property>
-            <property name="primary_icon_sensitive">False</property>
-            <property name="placeholder_text" translatable="yes">Game name or AppID..</property>
-            <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NONE</property>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSearchEntry" id="achievement_search_bar">
-            <property name="can_focus">True</property>
-            <property name="width_chars">26</property>
-            <property name="primary_icon_name">edit-find-symbolic</property>
-            <property name="primary_icon_activatable">False</property>
-            <property name="primary_icon_sensitive">False</property>
-            <property name="placeholder_text" translatable="yes">Name of the achievement...</property>
-            <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NONE</property>
-          </object>
-          <packing>
-            <property name="position">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSearchEntry" id="stat_search_bar">
-            <property name="can_focus">True</property>
-            <property name="width_chars">26</property>
-            <property name="primary_icon_name">edit-find-symbolic</property>
-            <property name="primary_icon_activatable">False</property>
-            <property name="primary_icon_sensitive">False</property>
-            <property name="placeholder_text" translatable="yes">Name of the stat...</property>
-            <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NONE</property>
-          </object>
-          <packing>
-            <property name="position">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkMenuButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="popover">popovermenu</property>
-            <child>
-              <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">open-menu-symbolic</property>
-                <property name="icon_size">1</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="store_button">
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="tooltip_text" translatable="yes">Confirm changes &amp; send to Steam</property>
-            <child>
-              <object class="GtkImage">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">document-save-symbolic</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="pack_type">end</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-      </object>
-    </child>
     <child>
       <object class="GtkStack" id="main_stack">
         <property name="visible">True</property>
@@ -965,7 +895,7 @@ Did you make a typo? Or maybe this game has no stats.</property>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">🏅 Achievements</property>
+                <property name="label" translatable="yes">🏆 Achievement</property>
                 <property name="width_chars">20</property>
                 <property name="max_width_chars">20</property>
               </object>
@@ -1020,6 +950,113 @@ Did you make a typo? Or maybe this game has no stats.</property>
         </child>
       </object>
     </child>
+    <child type="titlebar">
+      <object class="GtkHeaderBar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="title">SamRewritten</property>
+        <property name="subtitle">Steam Achievement Manager</property>
+        <property name="show_close_button">True</property>
+        <child>
+          <object class="GtkSearchEntry" id="game_search_bar">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="width_chars">26</property>
+            <property name="primary_icon_name">edit-find-symbolic</property>
+            <property name="primary_icon_activatable">False</property>
+            <property name="primary_icon_sensitive">False</property>
+            <property name="placeholder_text" translatable="yes">Game name or AppID..</property>
+            <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NONE</property>
+          </object>
+          <packing>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkMenuButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="popover">popovermenu</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">open-menu-symbolic</property>
+                <property name="icon_size">1</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="back_button">
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Return to the game list</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">go-previous-symbolic</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="store_button">
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Confirm changes &amp; send to Steam</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">document-save-symbolic</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSearchEntry" id="achievement_search_bar">
+            <property name="can_focus">True</property>
+            <property name="width_chars">26</property>
+            <property name="primary_icon_name">edit-find-symbolic</property>
+            <property name="primary_icon_activatable">False</property>
+            <property name="primary_icon_sensitive">False</property>
+            <property name="placeholder_text" translatable="yes">Name of the achievement...</property>
+            <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NONE</property>
+          </object>
+          <packing>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSearchEntry" id="stat_search_bar">
+            <property name="can_focus">True</property>
+            <property name="width_chars">26</property>
+            <property name="primary_icon_name">edit-find-symbolic</property>
+            <property name="primary_icon_activatable">False</property>
+            <property name="primary_icon_sensitive">False</property>
+            <property name="placeholder_text" translatable="yes">Name of the stat...</property>
+            <property name="input_hints">GTK_INPUT_HINT_NO_SPELLCHECK | GTK_INPUT_HINT_NONE</property>
+          </object>
+          <packing>
+            <property name="position">5</property>
+          </packing>
+        </child>
+      </object>
+    </child>
   </object>
   <object class="GtkWindow" id="settings_window">
     <property name="height_request">250</property>
@@ -1028,9 +1065,6 @@ Did you make a typo? Or maybe this game has no stats.</property>
     <property name="modal">True</property>
     <property name="destroy_with_parent">True</property>
     <property name="icon_name">preferences-system</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
     <child>
       <object class="GtkPaned">
         <property name="visible">True</property>
@@ -1261,6 +1295,9 @@ Did you make a typo? Or maybe this game has no stats.</property>
           </packing>
         </child>
       </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/src/gui/MainPickerWindow.cpp
+++ b/src/gui/MainPickerWindow.cpp
@@ -33,11 +33,14 @@ MainPickerWindow::MainPickerWindow(GtkApplicationWindow* cobject, const Glib::Re
     m_builder->get_widget("refresh_games_button", m_refresh_games_button);
     m_builder->get_widget("about_button", m_about_button);
     m_builder->get_widget("refresh_achievements_button", m_refresh_achievements_button);
+    m_builder->get_widget("separator_lock", m_separator_lock);
     m_builder->get_widget("unlock_all_achievements_button", m_unlock_all_achievements_button);
     m_builder->get_widget("lock_all_achievements_button", m_lock_all_achievements_button);
     m_builder->get_widget("invert_all_achievements_button", m_invert_all_achievements_button);
+    m_builder->get_widget("separator_display", m_separator_display);
     m_builder->get_widget("display_only_locked_button", m_display_only_locked_button);
     m_builder->get_widget("display_only_unlocked_button", m_display_only_unlocked_button);
+    m_builder->get_widget("separator_timed", m_separator_timed);
     m_builder->get_widget("start_timed_modifications_button", m_start_timed_modifications_button);
     m_builder->get_widget("fetch_games_placeholder", m_fetch_games_placeholder);
     m_builder->get_widget("no_games_found_placeholder", m_no_games_found_placeholder);
@@ -600,11 +603,14 @@ MainPickerWindow::switch_to_achievement_page() {
     m_stat_search_bar->set_visible(false);
     m_store_button->set_visible(true);
     m_refresh_achievements_button->set_visible(true);
+    m_separator_lock->set_visible(true);
     m_unlock_all_achievements_button->set_visible(true);
     m_lock_all_achievements_button->set_visible(true);
     m_invert_all_achievements_button->set_visible(true);
+    m_separator_display->set_visible(true);
     m_display_only_locked_button->set_visible(true);
     m_display_only_unlocked_button->set_visible(true);
+    m_separator_timed->set_visible(true);
     m_start_timed_modifications_button->set_visible(true);
 
     m_refresh_games_button->set_visible(false);
@@ -624,13 +630,16 @@ MainPickerWindow::switch_to_games_page() {
     m_stat_search_bar->set_visible(false);
     m_store_button->set_visible(false);
     m_refresh_achievements_button->set_visible(false);
+    m_separator_lock->set_visible(false);
     m_unlock_all_achievements_button->set_visible(false);
     m_lock_all_achievements_button->set_visible(false);
     m_invert_all_achievements_button->set_visible(false);
+    m_separator_display->set_visible(false);
     m_display_only_locked_button->set_visible(false);
     m_display_only_unlocked_button->set_visible(false);
     m_display_only_locked_button->set_active(false);
     m_display_only_unlocked_button->set_active(false);
+    m_separator_timed->set_visible(false);
     m_start_timed_modifications_button->set_visible(false);
 
     m_refresh_games_button->set_visible(true);

--- a/src/gui/MainPickerWindow.h
+++ b/src/gui/MainPickerWindow.h
@@ -21,6 +21,7 @@
 #include <gtkmm-3.0/gtkmm/spinbutton.h>
 #include <gtkmm-3.0/gtkmm/combobox.h>
 #include <gtkmm-3.0/gtkmm/radiobutton.h>
+#include <gtkmm-3.0/gtkmm/separator.h>
 
 /**
  * The main GUI class to display both the games ans the achievements to the user
@@ -172,9 +173,11 @@ private:
     Gtk::Button *m_refresh_games_button;
     Gtk::ModelButton *m_about_button;
     Gtk::ModelButton *m_refresh_achievements_button;
+    Gtk::Separator *m_separator_lock;
     Gtk::ModelButton *m_unlock_all_achievements_button;
     Gtk::ModelButton *m_lock_all_achievements_button;
     Gtk::ModelButton *m_invert_all_achievements_button;
+    Gtk::Separator *m_separator_display;
     // Currently these are checkbuttons and don't close the popover
     // when they're clicked. That might be desirable.
     // They could be made to be Gtk::ModelButton's like the other
@@ -182,6 +185,7 @@ private:
     // approximately the same way and doesn't close the popover
     Gtk::CheckButton *m_display_only_locked_button;
     Gtk::CheckButton *m_display_only_unlocked_button;
+    Gtk::Separator *m_separator_timed;
     Gtk::ModelButton *m_start_timed_modifications_button;
     Gtk::ListBox *m_game_list;
     Gtk::ListBox *m_achievement_list;


### PR DESCRIPTION
Popmenu now looks like other gtk+ applications.
![image](https://user-images.githubusercontent.com/60342258/85931974-e1400900-b8d0-11ea-979b-313f487453ec.png)
![image](https://user-images.githubusercontent.com/60342258/85931976-e735ea00-b8d0-11ea-91e0-ad1fefafe666.png)

Nautilus:
![image](https://user-images.githubusercontent.com/60342258/85931986-fa48ba00-b8d0-11ea-9c1f-ecd694cf48bb.png)

Also changed emoji for fix on some fonts.
![image](https://user-images.githubusercontent.com/60342258/85931997-1c423c80-b8d1-11ea-819e-d295ebe87fab.png)
