### PR TITLE
avoid a subshell+dirname on every compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,5 @@ ${CURDIR}/bin/samrewritten: $(OBJS)
 	${CXX} -o ${CURDIR}/bin/samrewritten $(OBJS) ${LDFLAGS} ${CXXFLAGS}
 
 ${OBJDIR}/%.o: %.cpp $(HFILES)
-	@mkdir -p $$(dirname $@)
+	@mkdir -p $(@D)
 	$(CXX) -c -o $@ $< ${LDFLAGS} $(CXXFLAGS)


### PR DESCRIPTION
The $(@D) variable is defined by POSIX and GNU Make to be the dirname
part of $@.  So it's equivalent to `dirname $@`, but faster & cheaper.