### PR TITLE
CLI idle exit with success

### DIFF
--- a/src/cli/cli_funcs.cpp
+++ b/src/cli/cli_funcs.cpp
@@ -13,7 +13,6 @@
 void handle_sigint_cli(int signum) 
 {
     std::cout << "Quitting cli idling" << std::endl;
-    g_steam->quit_game();
     exit(EXIT_SUCCESS);
 }
 
@@ -21,7 +20,13 @@ void idle_app(AppId_t appid)
 {
     std::cout << "Idling from command line " << appid << std::endl;
     g_steam->launch_app(appid);
-    signal(SIGINT, handle_sigint_cli);
+    struct sigaction sigIntHandler;
+
+    sigIntHandler.sa_handler = handle_sigint_cli;
+    sigemptyset(&sigIntHandler.sa_mask);
+    sigIntHandler.sa_flags = 0;
+
+    sigaction(SIGINT, &sigIntHandler, NULL);
 
     // Wait for ctrl+c, so we can kill both processes, otherwise
     // GUI process will exit while game process still goes on
@@ -221,7 +226,13 @@ bool go_cli_mode(int argc, char* argv[], AppId_t *return_app_id) {
         if (result.count("timed") > 0) {
             // Hook this up since we'll probably be in this function for a while
             // Really we could hook this up whenever we launch the app...
-            signal(SIGINT, handle_sigint_cli);
+            struct sigaction sigIntHandler;
+
+            sigIntHandler.sa_handler = handle_sigint_cli;
+            sigemptyset(&sigIntHandler.sa_mask);
+            sigIntHandler.sa_flags = 0;
+
+            sigaction(SIGINT, &sigIntHandler, NULL);
 
             if (app == 0)
             {


### PR DESCRIPTION
This one is tricky, cause when idling, and you break with SIGINT CTRL+C, you get message that pipe broke - even you should exit successfully. I tried to find issue and looks like some issues not catching correctly SIGINT is fixed by new method and to not have message just need to exit successfully and game exists by itself without error. Cause read_count was called and EXIT successfully in handle_sigint_cli not had chance to execute. Maybe you have another idea how to fix it.
It does not break anything and on SIGINT won't show popup with error. Game is quitted and there are no processes left.